### PR TITLE
Faster gradient square accumulation using hooks

### DIFF
--- a/run.py
+++ b/run.py
@@ -200,7 +200,8 @@ def train():
     if data_args.dataset == "c4":
         from datautils import get_loaders
         print("Calibration with C4 ")
-        dataloader, testloader = get_loaders(data_args.dataset,  model=model_args.model_name_or_path, seqlen=512)
+        dataloader, testloader = get_loaders(data_args.dataset,  model=model_args.model_name_or_path, seqlen=512,
+                                            nsamples=data_args.num_examples)
     else:
         raise NotImplementedError("Please define your own dataset here")
 

--- a/run.py
+++ b/run.py
@@ -225,6 +225,7 @@ def train():
     def square_grad_hook(grad):
         return grad.pow(2)
 
+    # Register custom hook to accumulate the square of gradients instead
     for layer in _layers:
         for module in get_modules(layer):
             module.weight.register_hook(square_grad_hook)
@@ -245,7 +246,7 @@ def train():
 
     print(f"saving model gradient at {training_args.output_dir}")
     model.save_pretrained(training_args.output_dir)
-    
+
 
 if __name__ == "__main__":
     train()


### PR DESCRIPTION
This PR fixes two things:

## Speedup

This PR achieves a speedup of more than 20x on an RTX 4090 for calculating the sum of gradients squared.

It does so by using the [`register_hook` method](https://pytorch.org/docs/stable/generated/torch.Tensor.register_hook.html) to have PyTorch calculate the gradient squared on every `loss.backward` invocation.

You simply take the `.grad` attribute of the weights at the very end for the accumulated sum of gradients squared.

I expect this PR to achieve speedups comparable to #6 , but without the extra code/model modification overhead, which is why I'm opening this PR despite #6 already being there.

I did a rough comparison of the resulting values against the original implementation and found that the values are close to identical.
I also tested with [SqueezeLLM](https://github.com/SqueezeAILab/SqueezeLLM) to confirm that the quantized models achieve the same perplexities.

You may do you own tests on this code before integration.

## num_examples bug fix

Fixed an issue where the `num_examples` argument was ineffective for values larger than 128, the default `nsamples` value for the `get_loaders` function.

This moves the sampling logic into the `get_loader` function, and also enables the `tqdm` loading bar to appear, as we don't need to use the `enumerate`.